### PR TITLE
Workflow for automatic docker build and publish

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,8 +1,8 @@
 name: Docker
 
 on:
-  push:
-    # Publish semver tags as releases.
+  release:
+    types: [published]
     tags: [ 'v*.*.*' ]
   
 env:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,59 @@
+name: Docker
+
+on:
+  push:
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*' ]
+  
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: gatewayuno.azurecr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.AZURE_USER }}
+          password: ${{ secrets.AZURE_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Push docker image
+        id: push
+        run:  |
+          
+          echo "version=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}"
+          echo "steps = ${{ steps.meta.outputs.tags }}"
+          docker build . --file Dockerfile --tag $IMAGE_NAME:${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+          echo "tag and push images"
+          while IFS= read -r tag; do
+            echo "push tag: $tag"
+            docker image tag $IMAGE_NAME:${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }} $tag
+            docker image push $tag
+          done <<< "${{steps.meta.outputs.tags}}"
+          


### PR DESCRIPTION
The added workflow automatically builds and publishes the docker image to `gatewayuno.azurecr.io` repository upon publishing a new release tagged with `vx.x.x`

The workflow requires two secrets:

- AZURE_USER
- AZURE_TOKEN